### PR TITLE
TBA API Integration, Match Schedule proxy APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation group: 'org.flywaydb', name: 'flyway-database-postgresql'
 
 	implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.3'
+	implementation group: 'org.json', name: 'json', version: '20250107'
 
 	runtimeOnly group: 'org.postgresql', name: 'postgresql'
 }

--- a/docker/application.yaml
+++ b/docker/application.yaml
@@ -21,3 +21,5 @@ spring:
 auth:
   url:
 
+tba:
+  key:

--- a/gearscout-api.yaml
+++ b/gearscout-api.yaml
@@ -292,6 +292,43 @@ paths:
           description: Empty response body
         default:
           $ref: '#/components/responses/GeneralError'
+  /v2/schedule/gameYear/{gameYear}/event/{eventCode}:
+    parameters:
+      - $ref: '#/components/parameters/gameYearPathParam'
+      - $ref: '#/components/parameters/eventCodePathParam'
+    get:
+      summary: Fetch qualification match schedule for an event
+      description: The event code must match the official 4-5 character FIRST
+        event code, which can be found on FIRST's website. For example, the Midwest
+        regional's event code is ILCH. If the event code contains a hyphen, only
+        the characters before the hyphen will be considered when querying for match
+        schedule. Foe example, event codes ILCH and ILCH-2 will both fetch match
+        schedules for the Midwest regional.
+      responses:
+        '200':
+          description: A match schedule in JSON format
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MatchScheduleBody'
+  /v2/schedule/team/{teamNumber}/gameYear/{gameYear}/event/{eventCode}:
+    parameters:
+      - $ref: '#/components/parameters/teamNumberPathParam'
+      - $ref: '#/components/parameters/gameYearPathParam'
+      - $ref: '#/components/parameters/eventCodePathParam'
+    get:
+      summary: Fetch qualification match schedule for one team at an event.
+      responses:
+        '200':
+          description: A match schedule in JSON format
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MatchScheduleBody'
 
 components:
   parameters:
@@ -371,6 +408,12 @@ components:
       format: int32
       minimum: 0
       description: Team number that owns the data
+      example: 2338
+    teamNumberSchedule:
+      type: integer
+      format: int32
+      minimum: 0
+      description: Team number in this match
       example: 2338
     gameYear:
       type: integer
@@ -676,6 +719,17 @@ components:
           $ref: '#/components/schemas/creator'
         timeCreated:
           $ref: '#/components/schemas/unixTimestamp'
+    MatchScheduleBody:
+      type: object
+      properties:
+        matchNumber: '#/components/schemas/matchNumber'
+        red1: '#/components/schemas/teamNumberSchedule'
+        red2: '#/components/schemas/teamNumberSchedule'
+        red3: '#/components/schemas/teamNumberSchedule'
+        blue1: '#/components/schemas/teamNumberSchedule'
+        blue2: '#/components/schemas/teamNumberSchedule'
+        blue3: '#/components/schemas/teamNumberSchedule'
+
     ErrorModel:
       type: string
 

--- a/src/main/java/team/gif/gearscout/schedule/ScheduleController.java
+++ b/src/main/java/team/gif/gearscout/schedule/ScheduleController.java
@@ -1,0 +1,60 @@
+package team.gif.gearscout.schedule;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.PathVariable;
+import team.gif.gearscout.shared.UserRoles;
+import team.gif.gearscout.token.TokenService;
+import team.gif.gearscout.tba.TbaService;
+import team.gif.gearscout.tba.MatchScheduleEntry;
+
+import java.util.*;
+
+@RestController
+@RequestMapping(value = "/api/v2/schedule", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ScheduleController {
+    private static final Logger logger = LogManager.getLogger(ScheduleController.class);
+
+    private final TbaService tbaService;
+
+    @Autowired
+	public ScheduleController(
+		TbaService tbaService
+	) {
+        this.tbaService = tbaService;
+    }
+
+    @GetMapping(value = "/gameYear/{gameYear}/event/{eventCode}")
+    public ResponseEntity<List<MatchScheduleEntry>> getScheduleForEvent(
+        @PathVariable Integer gameYear,
+        @PathVariable String eventCode
+    ) {
+        logger.debug("Received getScheduleForEvent request: {}, {}", gameYear, eventCode);
+
+        List<MatchScheduleEntry> result = tbaService.getMatchSchedule(eventCode, gameYear);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping(value = "/team/{teamNumber}/gameYear/{gameYear}/event/{eventCode}")
+    public ResponseEntity<List<MatchScheduleEntry>> getScheduleForTeam(
+        @PathVariable Integer teamNumber,
+        @PathVariable Integer gameYear,
+        @PathVariable String eventCode
+    ) {
+        logger.debug("Received getScheduleForTeam request: {}, {}, {}", teamNumber, gameYear, eventCode);
+
+        List<MatchScheduleEntry> result = tbaService.getMatchesForTeam(eventCode, gameYear, teamNumber);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/team/gif/gearscout/tba/MatchScheduleEntry.java
+++ b/src/main/java/team/gif/gearscout/tba/MatchScheduleEntry.java
@@ -1,0 +1,107 @@
+package team.gif.gearscout.tba;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.*;
+
+import org.json.*;
+
+import java.util.Optional;
+import java.util.ArrayList;
+
+public class MatchScheduleEntry implements Comparable<MatchScheduleEntry> {
+    private static final Logger logger = LogManager.getLogger(MatchScheduleEntry.class);
+
+    int matchNumber;
+    int red1;
+    int red2;
+    int red3;
+    int blue1;
+    int blue2;
+    int blue3;
+
+    public MatchScheduleEntry(int matchNumber, int red1, int red2, int red3, int blue1, int blue2, int blue3) {
+        this.matchNumber = matchNumber;
+        this.red1 = red1;
+        this.red2 = red2;
+        this.red3 = red3;
+        this.blue1 = blue1;
+        this.blue2 = blue2;
+        this.blue3 = blue3;
+    }
+
+    public static MatchScheduleEntry fromTbaJson(JSONObject json) {
+        if (!json.getString("comp_level").equals("qm")) {
+            return null;
+        }
+
+        JSONObject alliances = json.getJSONObject("alliances");
+        JSONArray redTeamKeys = alliances.getJSONObject("red")
+            .getJSONArray("team_keys");
+        ArrayList<Integer> redTeams = getTeamNumbers(redTeamKeys);
+
+        JSONArray blueTeamKeys = alliances.getJSONObject("blue")
+            .getJSONArray("team_keys");
+        ArrayList<Integer> blueTeams = getTeamNumbers(blueTeamKeys);
+
+        int matchNumber = json.optInt("match_number", 0);
+
+        return new MatchScheduleEntry(matchNumber,
+            redTeams.size() > 0 ? redTeams.get(0) : 0,
+            redTeams.size() > 1 ? redTeams.get(1) : 0,
+            redTeams.size() > 2 ? redTeams.get(2) : 0,
+            blueTeams.size() > 0 ? blueTeams.get(0) : 0,
+            blueTeams.size() > 1 ? blueTeams.get(1) : 0,
+            blueTeams.size() > 2 ? blueTeams.get(2) : 0
+        );
+    }
+
+    private static ArrayList<Integer> getTeamNumbers(JSONArray teamKeys) {
+        ArrayList<Integer> result = new ArrayList();
+        for (int i = 0; i < teamKeys.length(); ++i) {
+            String val = teamKeys.optString(i, "frc0").substring(3);
+            result.add(Integer.parseInt(val));
+        }
+        return result;
+    }
+
+    @JSONPropertyName("matchNumber")
+    public int getMatchNumber() {
+        return matchNumber;
+    }
+
+    @JSONPropertyName("red1")
+    public int getRed1() {
+        return red1;
+    }
+
+    @JSONPropertyName("red2")
+    public int getRed2() {
+        return red2;
+    }
+
+    @JSONPropertyName("red3")
+    public int getRed3() {
+        return red3;
+    }
+
+    @JSONPropertyName("blue1")
+    public int getBlue1() {
+        return blue1;
+    }
+
+    @JSONPropertyName("blue2")
+    public int getBlue2() {
+        return blue2;
+    }
+
+    @JSONPropertyName("blue3")
+    public int getBlue3() {
+        return blue3;
+    }
+
+    @Override
+    public int compareTo(MatchScheduleEntry b) {
+        return Integer.compare(getMatchNumber(), b.getMatchNumber());
+    }
+}

--- a/src/main/java/team/gif/gearscout/tba/TbaClient.java
+++ b/src/main/java/team/gif/gearscout/tba/TbaClient.java
@@ -1,0 +1,222 @@
+package team.gif.gearscout.tba;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.*;
+
+import javax.net.ssl.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.net.http.*;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpClient.Redirect;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class TbaClient {
+    private static final Logger logger = LogManager.getLogger(TbaClient.class);
+    private static final String baseUri = "https://www.thebluealliance.com/api/v3/";
+    private static final long minCacheAgeSeconds = 1800; // we don't need match results, only the schedule, so a slow refresh is fine
+
+    private final HttpClient httpClient = getHttpClient();
+
+	private String tbaApiKey;
+    private HashMap<String, GetAllMatchesForEventResponse> cachedMatchResponses;
+
+    public TbaClient(String tbaApiKey) {
+        this.tbaApiKey = tbaApiKey;
+        this.cachedMatchResponses = new HashMap();
+    }
+
+    public boolean isOk() {
+        try {
+            HttpRequest request = getHttpRequest("status").build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.statusCode() == 200;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Query TBA's /event/{eventKey}/matches/simple endpoint.
+     */
+    public ArrayList<MatchScheduleEntry> getMatchSchedule(String eventKey) {
+        // check if current cache entry is valid
+        GetAllMatchesForEventResponse resp = cachedMatchResponses.get(eventKey);
+        long now = System.currentTimeMillis();
+        if (resp != null && now < resp.expiration) {
+            long timeToExpiry = (resp.expiration - now + 500) / 1000;
+            logger.info("Using cached match schedule (" + timeToExpiry + " secs to expiry)");
+            return resp.data;
+        }
+
+        // send out a request
+        HttpResponse<String> response = null;
+
+        try {
+            HttpRequest.Builder builder = getHttpRequest("/event/" + eventKey + "/matches/simple")
+                .setHeader("Cache-Control", "max-age=3600");
+            if (resp != null && resp.cacheTag != null) {
+                builder = builder.setHeader("If-None-Match", resp.cacheTag);
+            }
+
+            HttpRequest request = builder.build();
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            logger.error("Failed while querying TBA: {}", e);
+        }
+
+        return updateMatchCache(eventKey, response);
+    }
+
+    private ArrayList<MatchScheduleEntry> updateMatchCache(String eventKey, HttpResponse<String> response) {
+        GetAllMatchesForEventResponse oldResp = cachedMatchResponses.get(eventKey);
+
+        if (response == null) {
+            if (oldResp == null) {
+                return null;
+            } else {
+                return oldResp.data;
+            }
+        }
+
+        GetAllMatchesForEventResponse newResp = new GetAllMatchesForEventResponse(response);
+
+        if (response.statusCode() == 304) {
+            // "not modified" response -> bump up the cache expiration time and return cached data
+            oldResp.expiration = newResp.expiration;
+            cachedMatchResponses.put(eventKey, oldResp);
+            return oldResp.data;
+        } else if (response.statusCode() == 200 && newResp.data != null) {
+            // new data arrived, update cache
+            logger.warn("Fresh data received from TBA, updating cache entry");
+            cachedMatchResponses.put(eventKey, newResp);
+            return newResp.data;
+        } else {
+            // something weird happened, ignore the new response
+            logger.warn("Unexpected status {} from TBA", response.statusCode());
+            return oldResp.data;
+        }
+    }
+
+    private HttpRequest.Builder getHttpRequest(String path) throws URISyntaxException {
+        return HttpRequest.newBuilder()
+            .setHeader("User-Agent", "GearScout")
+            .setHeader("accept", "application/json")
+            .setHeader("X-TBA-Auth-Key", tbaApiKey)
+            .uri(new URI(baseUri + path))
+            .GET();
+    }
+
+    // Scaffolding for HTTPS client that talks to TBA
+    private static HttpClient getHttpClient() {
+        TrustManager[] trustAllCertificates = new TrustManager[]{
+            new X509TrustManager() {
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                }
+            }
+        };
+
+        SSLContext sslContext = null;
+        try {
+            sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustAllCertificates, new java.security.SecureRandom());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(Redirect.ALWAYS)
+                .build();
+    }
+
+    class GetAllMatchesForEventResponse {
+        ArrayList<MatchScheduleEntry> data;
+        String cacheTag;
+        long expiration;
+
+        GetAllMatchesForEventResponse(HttpResponse<String> response) {
+            try {
+                JSONArray matches = new JSONArray(response.body());
+                this.data = new ArrayList();
+                for (int i = 0; i < matches.length(); ++i) {
+                    JSONObject obj = matches.optJSONObject(i);
+
+                    MatchScheduleEntry entry = MatchScheduleEntry.fromTbaJson(obj);
+                    if (entry == null) {
+                        // this entry was for practice mach, elims, or something else. ignore it
+                        continue;
+                    }
+
+                    this.data.add(entry);
+                }
+                // this.data.sort(null);
+            } catch (Exception e) {
+                logger.error("Error while parsing: {}", e);
+                this.data = null;
+            }
+    
+            Optional<String> cacheTag = response.headers().firstValue("etag");
+            if (cacheTag.isPresent()) {
+                this.cacheTag = cacheTag.get();
+            }
+
+            String cacheControl = response.headers().firstValue("Cache-Control").get();
+            String maxAgeString = null;
+            long maxAgeInt;
+
+            if (cacheControl != null) {
+                maxAgeString = parseCacheControlHeader(cacheControl).get("max-age");
+            }
+
+            if (maxAgeString != null) {
+                maxAgeInt = Integer.parseInt(maxAgeString);
+            } else {
+                maxAgeInt = -1;
+            }
+
+            if (maxAgeInt < minCacheAgeSeconds) {
+                maxAgeInt = minCacheAgeSeconds;
+            }
+
+            this.expiration = System.currentTimeMillis() + (maxAgeInt * 1000);
+        }
+
+        private static HashMap<String, String> parseCacheControlHeader(String cacheControlHeader) {
+            HashMap<String, String> directives = new HashMap<>();
+
+            // split Cache-Control header by commas, trim whitespace
+            String[] tokens = cacheControlHeader.split(",");
+            for (String token : tokens) {
+                String[] parts = token.trim().split("=", 2);
+                if (parts.length == 2) {
+                    // If there's an equals sign, it's a key-value pair
+                    directives.put(parts[0].trim(), parts[1].trim());
+                } else {
+                    // Otherwise, it's just a directive without a value
+                    directives.put(parts[0].trim(), null);
+                }
+            }
+
+            return directives;
+        }
+    }
+}

--- a/src/main/java/team/gif/gearscout/tba/TbaService.java
+++ b/src/main/java/team/gif/gearscout/tba/TbaService.java
@@ -1,0 +1,61 @@
+package team.gif.gearscout.tba;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
+import java.util.stream.*;
+import java.util.*;
+import team.gif.gearscout.tba.MatchScheduleEntry;
+
+@Service
+@Transactional
+public class TbaService {
+    private TbaClient tbaClient;
+
+    @Autowired
+    public TbaService(@Value("${tba.key}") String tbaApiKey) {
+        this.tbaClient = new TbaClient(tbaApiKey);
+    }
+
+    public boolean checkOnline() {
+        return tbaClient.isOk();
+    }
+
+    public List<MatchScheduleEntry> getMatchSchedule(String eventCode, int year, int start, int end) {
+        String tbaEventId = tbaEventIdFromParts(eventCode, year);
+        ArrayList<MatchScheduleEntry> schedule = tbaClient.getMatchSchedule(tbaEventId);
+
+        if (schedule == null) {
+            return new ArrayList();
+        }
+
+        return schedule.stream()
+            .filter(m -> m.getMatchNumber() >= start && m.getMatchNumber() <= end)
+            .sorted()
+            .collect(Collectors.toList());
+    }
+
+    public List<MatchScheduleEntry> getMatchSchedule(String eventCode, int year) {
+        return getMatchSchedule(eventCode, year, 1, 9999);
+    }
+
+    public List<MatchScheduleEntry> getMatchesForTeam(String eventCode, int year, int team) {
+        String tbaEventId = tbaEventIdFromParts(eventCode, year);
+        ArrayList<MatchScheduleEntry> schedule = tbaClient.getMatchSchedule(tbaEventId);
+
+        if (schedule == null) {
+            return new ArrayList();
+        }
+
+        return schedule.stream()
+            .filter(m -> (m.getRed1() == team || m.getRed2() == team || m.getRed3() == team
+                      || m.getBlue1() == team || m.getBlue2() == team || m.getBlue3() == team))
+            .sorted()
+            .collect(Collectors.toList());
+    }
+
+    private static String tbaEventIdFromParts(String eventCode, int year) {
+        String eventSlug = eventCode.split("-")[0].toLowerCase();
+        return String.valueOf(year) + eventSlug;
+    }
+}


### PR DESCRIPTION
Add two new backend endpoints:

# /api/v2/schedule/gameYear/{gameYear}/event/{eventCode}

Pulls a complete match schedule for a particular event. Example response:

```
[{"matchNumber":1,"red1":4292,"red2":2022,"red3":648,"blue1":2039,"blue2":4645,"blue3":2136},{"matchNumber":2,"red1":1781,"red2":1625,"red3":2338,"blue1":4551,"blue2":4787,"blue3":2512},{"matchNumber":3,"red1":3061,"red2":3177,"red3":4302,"blue1":4324,"blue2":4081,"blue3":677},{"matchNumber":4,"red1":2709,"red2":3940,"red3":101,"blue1":4676,"blue2":2115,"blue3":4702},{"matchNumber":5,"red1":2010,"red2":2781,"red3":1675,"blue1":3110,"blue2":3135,"blue3":3067},{"matchNumber":6,"red1":2905,"red2":71,"red3":1850,"blue1":2725,"blue2":2432,"blue3":2151},{"matchNumber":7,"red1":2194,"red2":3646,"red3":3488,"blue1":3936,"blue2":4096,"blue3":1739},{"matchNumber":8,"red1":2803,"red2":2358,"red3":4241,"blue1":3390,"blue2":3352,"blue3":3695},{"matchNumber":9,"red1":2704,"red2":2451,"red3":3197,"blue1":111,"blue2":1091,"blue3":2136},{"matchNumber":10,"red1":2010,"red2":4645,"red3":4676,"blue1":4787,"blue2":2781,"blue3":2039},
...
]
```

# /api/v2/schedule/team/{team}/gameYear/{gameYear}/event/{eventCode}

Pulls a complete match schedule for a particular team at an event. Example response:

```
[{"matchNumber":2,"red1":1781,"red2":1625,"red3":2338,"blue1":4551,"blue2":4787,"blue3":2512},{"matchNumber":17,"red1":111,"red2":3135,"red3":2338,"blue1":3177,"blue2":2725,"blue3":3936},{"matchNumber":21,"red1":4241,"red2":4676,"red3":2432,"blue1":3110,"blue2":2151,"blue3":2338},{"matchNumber":32,"red1":4302,"red2":2781,"red3":2115,"blue1":3695,"blue2":2338,"blue3":1850},{"matchNumber":42,"red1":71,"red2":2010,"red3":3646,"blue1":1675,"blue2":2338,"blue3":3061},{"matchNumber":49,"red1":2338,"red2":4702,"red3":3352,"blue1":4081,"blue2":2194,"blue3":2704},{"matchNumber":57,"red1":4645,"red2":4702,"red3":1625,"blue1":2725,"blue2":1739,"blue3":2338},{"matchNumber":63,"red1":2338,"red2":4241,"red3":2022,"blue1":1739,"blue2":101,"blue3":2451},{"matchNumber":77,"red1":2358,"red2":2905,"red3":4292,"blue1":2338,"blue2":4096,"blue3":2115},{"matchNumber":88,"red1":3177,"red2":2338,"red3":2709,"blue1":3488,"blue2":3940,"blue3":3067}]
```

Both APIs rely on TBA to function. This means that your event code has to match the standard FIRST event codes for these APIs for work. So, if you want to get match schedules for Midwest, your event code must be ILCH. There is a little flexibility, though. These APIs are case-insensitive (`ilch` and `ILCH` will both give you schedules for Midwest), and they ignore anything following a hyphen (ex: `ILCH` and `ILCH-1` will both give you schedules for Midwest).