### PR TITLE
Stats page UX improvements

### DIFF
--- a/client/apps/analytics/.env
+++ b/client/apps/analytics/.env
@@ -1,5 +1,5 @@
 #VITE_APP_VERSION=$npm_package_version
-VITE_APP_VERSION=2025.2
+VITE_APP_VERSION=2025.2.1
 VITE_APP_SERVER_URL=https://data.gearitforward.com/api
 #VITE_APP_SERVER_URL=https://dev-data.gearitforward.com/api
 #VITE_APP_SERVER_URL=http://localhost:8080/api

--- a/client/apps/analytics/src/components/stat-page/StatPage.scss
+++ b/client/apps/analytics/src/components/stat-page/StatPage.scss
@@ -7,11 +7,6 @@
 	.stat-list-wrapper {
 		width: var(--stat-sidenav-width);
 		min-width: var(--stat-sidenav-width);
-		box-sizing: border-box;
-		display: flex;
-		flex-direction: column;
-		border-right: 1px solid var(--border-color);
-		overflow-y: auto;
 	}
 
 	.stat-content {

--- a/client/apps/analytics/src/components/stat-page/StatPage.tsx
+++ b/client/apps/analytics/src/components/stat-page/StatPage.tsx
@@ -102,12 +102,11 @@ function StatPage() {
 	return (
 		<Fragment>
 			<main className="page stat-page">
-				<div className="stat-list-wrapper">
-					<StatList
-						stats={ stats }
-						selectedStats={ selectedStats }
-					/>
-				</div>
+				<StatList
+					className="stat-list-wrapper"
+					stats={ stats }
+					selectedStats={ selectedStats }
+				/>
 				{ content }
 			</main>
 			<TeamDetailModal

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatList.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatList.scss
@@ -1,34 +1,43 @@
 
-.stat-list-header {
-	position: sticky;
+._stat-list {
+	--stat-header-height: 52px;
 	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	top: 0;
-	padding: 16px 16px 0 16px;
-	background-color: #fff;
-	z-index: 999;
+	flex-direction: column;
+	box-sizing: border-box;
+	border-right: 1px solid var(--border-color);
+	overflow-y: auto;
 
-	.page-title {
-		font-weight: 500;
-		font-size: 24px;
-		line-height: 36px;
-		letter-spacing: 0.0075em;
-		margin: 0;
+	.stat-list-header {
+		position: sticky;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		top: 0;
+		padding: 16px 16px 0 16px;
+		background-color: #fff;
+		z-index: 999;
+
+		.page-title {
+			font-weight: 500;
+			font-size: 24px;
+			line-height: 36px;
+			letter-spacing: 0.0075em;
+			margin: 0;
+		}
+
+		#clear-button {
+			font-size: 14px;
+			line-height: 20px;
+		}
 	}
 
-	#clear-button {
-		font-size: 14px;
-		line-height: 20px;
+	.stat-list-item {
+		margin-right: auto;
 	}
-}
 
-.stat-list-item {
-	margin-right: auto;
-}
-
-.stat-list-color-legend {
-	height: 8px;
-	width: 8px;
-	border-radius: 2px;
+	.stat-list-color-legend {
+		height: 8px;
+		width: 8px;
+		border-radius: 2px;
+	}
 }

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatList.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatList.scss
@@ -1,9 +1,13 @@
 
 .stat-list-header {
+	position: sticky;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	top: 0;
 	padding: 16px 16px 0 16px;
+	background-color: #fff;
+	z-index: 999;
 
 	.page-title {
 		font-weight: 500;

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
@@ -11,6 +11,12 @@ interface IProps {
 	selectedStats: ObjectiveDescriptor[];
 }
 
+const ORDERING: Record<string, string> = {
+	'AUTO': '0',
+	'TELEOP': '1',
+	'SUPERSCOUT': '99'
+};
+
 export default function StatList({ className, stats, selectedStats }: IProps) {
 
 	const translate = useTranslator();
@@ -29,20 +35,23 @@ export default function StatList({ className, stats, selectedStats }: IProps) {
 		statsGroupedByGamemode.get(stat.gamemode).push(stat);
 	}
 
-	const listItems = [];
-	statsGroupedByGamemode.forEach((objectives: GlobalObjectiveStats[], gamemode: string) => {
-		listItems.push(
-			<StatListSection
-				key={ gamemode }
-				gamemode={ gamemode }
-				stats={ objectives }
-				selectedStats={ selectedStats }
-				selectStat={(objective: string) => _setSelectedStat(gamemode, objective)}
-				addSelectedStat={ (objective: string) => _addSelectedStat(gamemode, objective) }
-				removeSelectedStat={ (objective: string) => _removeSelectedStat(gamemode, objective) }
-			/>
-		);
-	});
+	const listItems = statsGroupedByGamemode.keys()
+		.toArray()
+		.toSorted((a: string, b: string) => (ORDERING[a] ?? a).localeCompare(ORDERING[b] ?? b))
+		.map((gamemode: string) => {
+			const objectives: GlobalObjectiveStats[] = statsGroupedByGamemode.get(gamemode);
+			return (
+				<StatListSection
+					key={ gamemode }
+					gamemode={ gamemode }
+					stats={ objectives }
+					selectedStats={ selectedStats }
+					selectStat={(objective: string) => _setSelectedStat(gamemode, objective)}
+					addSelectedStat={ (objective: string) => _addSelectedStat(gamemode, objective) }
+					removeSelectedStat={ (objective: string) => _removeSelectedStat(gamemode, objective) }
+				/>
+			);
+		});
 
 	return (
 		<div className={ `_stat-list ${ className ?? '' }` }>
@@ -59,11 +68,7 @@ export default function StatList({ className, stats, selectedStats }: IProps) {
 					</Button>
 				}
 			</div>
-			<List
-				sx={{
-					paddingTop: 0
-				}}
-			>
+			<List sx={{ paddingTop: 0 }}>
 				{ listItems }
 			</List>
 		</div>

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
@@ -6,11 +6,12 @@ import StatListSection from './StatListSection';
 import { addSelectedStat, clearSelectedStats, removeSelectedStat, selectStat, useAppDispatch } from '../../../state';
 
 interface IProps {
+	className?: string;
 	stats: GlobalObjectiveStats[];
 	selectedStats: ObjectiveDescriptor[];
 }
 
-export default function StatList({ stats, selectedStats }: IProps) {
+export default function StatList({ className, stats, selectedStats }: IProps) {
 
 	const translate = useTranslator();
 	const dispatch = useAppDispatch();
@@ -44,7 +45,7 @@ export default function StatList({ stats, selectedStats }: IProps) {
 	});
 
 	return (
-		<React.Fragment>
+		<div className={ `_stat-list ${ className ?? '' }` }>
 			<div className="stat-list-header">
 				<h1 className="page-title">{ translate('STATS') }</h1>
 				{
@@ -65,6 +66,6 @@ export default function StatList({ stats, selectedStats }: IProps) {
 			>
 				{ listItems }
 			</List>
-		</React.Fragment>
+		</div>
 	);
 }

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
@@ -81,7 +81,7 @@ export default function StatListSection({ gamemode, stats, selectedStats, select
 
 	return (
 		<React.Fragment>
-			<ListSubheader>{ translate(gamemode) }</ListSubheader>
+			<ListSubheader sx={{ top: '52px' }}>{ translate(gamemode) }</ListSubheader>
 			{ items }
 		</React.Fragment>
 	);

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
@@ -81,7 +81,7 @@ export default function StatListSection({ gamemode, stats, selectedStats, select
 
 	return (
 		<React.Fragment>
-			<ListSubheader sx={{ top: '52px' }}>{ translate(gamemode) }</ListSubheader>
+			<ListSubheader style={{ top: 'var(--stat-header-height)' }}>{ translate(gamemode) }</ListSubheader>
 			{ items }
 		</React.Fragment>
 	);


### PR DESCRIPTION
* Made Stats title + "clear" button sticky
* Fixed ordering of stats to push "superscout" category to the bottom