### PR TITLE
[Analytics 2025.5] - Add bubble graph

### DIFF
--- a/client/apps/analytics/.env
+++ b/client/apps/analytics/.env
@@ -1,5 +1,5 @@
 #VITE_APP_VERSION=$npm_package_version
-VITE_APP_VERSION=2025.4.1
+VITE_APP_VERSION=2025.5
 VITE_APP_SERVER_URL=https://data.gearitforward.com/api
 #VITE_APP_SERVER_URL=https://dev-data.gearitforward.com/api
 #VITE_APP_SERVER_URL=http://localhost:8080/api

--- a/client/apps/analytics/src/components/stat-page/StatPage.scss
+++ b/client/apps/analytics/src/components/stat-page/StatPage.scss
@@ -9,6 +9,13 @@
 		min-width: var(--stat-sidenav-width);
 	}
 
+	.view-more-details-container {
+		display: flex;
+		justify-content: space-between;
+		padding: 16px;
+		width: 100%;
+	}
+
 	.stat-content {
 		display: flex;
 		flex-direction: column;

--- a/client/apps/analytics/src/components/stat-page/StatPage.tsx
+++ b/client/apps/analytics/src/components/stat-page/StatPage.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslator } from '../../service/TranslateService';
 import { getComments, getInspections, useAppDispatch, useAppSelector, useDataInitializer } from '../../state';
 import StatList from './stat-list/StatList';
+import StatPlot from './stat-plot/StatPlot';
 import StatTable from './stat-table/StatTable';
 import './StatPage.scss';
 import DataFailure from '../shared/data-failure/DataFailure';
@@ -21,6 +22,7 @@ import {
 	ToggleButtonGroup
 } from '@mui/material';
 import {
+	ScatterPlot,
 	StackedBarChart,
 	TableChart,
 	TableRows
@@ -29,7 +31,8 @@ import {
 enum ViewType {
 	barGraph = 'barGraph',
 	table = 'table',
-	barGraphTable = 'barGraphTable'
+	barGraphTable = 'barGraphTable',
+	scatterPlot = 'scatterPlot',
 }
 
 function StatPage() {
@@ -116,6 +119,9 @@ function StatPage() {
 						<ToggleButton value={ ViewType.barGraphTable } aria-label="Bar graph and table">
 							<TableChart />
 						</ToggleButton>
+						<ToggleButton value={ ViewType.scatterPlot } aria-label="Scatter plot">
+							<ScatterPlot />
+						</ToggleButton>
 					</ToggleButtonGroup>
 				</div>
 				{ (viewType === ViewType.barGraph || viewType === ViewType.barGraphTable) && (
@@ -135,6 +141,15 @@ function StatPage() {
 								: <StatTable data={ teamStats }/>
 						}
 					</div>
+				)}
+				{ (viewType === ViewType.scatterPlot) && (
+					<StatPlot
+						robots={ teamData }
+						horizontalObjectives={ selectedStats }
+						verticalObjectives={ selectedStats }
+						metric="mean"
+						selectRobot={ selectRobot }
+					/>
 				)}
 			</div>
 		);

--- a/client/apps/analytics/src/components/stat-page/StatPage.tsx
+++ b/client/apps/analytics/src/components/stat-page/StatPage.tsx
@@ -81,7 +81,12 @@ function StatPage() {
 		);
 	}
 
-	let content = <div>{ translate('SELECT_STAT_VIEW_MORE_DETAILS') }</div>;
+	let content = (
+		<div className="view-more-details-container">
+			<span>{ translate('SELECT_STAT_VIEW_MORE_DETAILS') }</span>
+			<ViewTypePicker viewType={ viewType } setViewType={ setViewType } />
+		</div>
+	);
 	if (selectedStats.length > 0) {
 		const teamStats: TeamObjectiveStats[] = teamData
 			.map((team: Team) => team.stats
@@ -102,28 +107,7 @@ function StatPage() {
 			<div className="stat-content">
 				<div className="stat-content-top-row">
 					<h2 className="stat-content-title">{ contentTitleText }</h2>
-					{/*TODO: Translate below*/}
-					<ToggleButtonGroup
-						size="small"
-						exclusive={ true }
-						value={ viewType }
-						onChange={ (_, next: ViewType) => setViewType(next) }
-						aria-label="Page layout"
-						sx={{ marginBottom: '8px' }}
-					>
-						<ToggleButton value={ ViewType.barGraph } aria-label="Bar graph only">
-							<StackedBarChart />
-						</ToggleButton>
-						<ToggleButton value={ ViewType.table } aria-label="Table only">
-							<TableRows />
-						</ToggleButton>
-						<ToggleButton value={ ViewType.barGraphTable } aria-label="Bar graph and table">
-							<TableChart />
-						</ToggleButton>
-						<ToggleButton value={ ViewType.scatterPlot } aria-label="Scatter plot">
-							<ScatterPlot />
-						</ToggleButton>
-					</ToggleButtonGroup>
+					<ViewTypePicker viewType={ viewType } setViewType={ setViewType } />
 				</div>
 				{ (viewType === ViewType.barGraph || viewType === ViewType.barGraphTable) && (
 					<StatGraphStacked
@@ -176,6 +160,33 @@ function StatPage() {
 				afterClose={ afterClose }
 			/>
 		</Fragment>
+	);
+}
+
+function ViewTypePicker(props: { viewType: ViewType, setViewType: (next: ViewType) => void }) {
+	/*TODO: Translate below*/
+	return (
+		<ToggleButtonGroup
+			size="small"
+			exclusive={ true }
+			value={ props.viewType }
+			onChange={ (_, next: ViewType) => props.setViewType(next) }
+			aria-label="Page layout"
+			sx={{ display: 'block', marginBottom: '8px' }}
+		>
+			<ToggleButton value={ ViewType.barGraph } aria-label="Bar graph only">
+				<StackedBarChart />
+			</ToggleButton>
+			<ToggleButton value={ ViewType.table } aria-label="Table only">
+				<TableRows />
+			</ToggleButton>
+			<ToggleButton value={ ViewType.barGraphTable } aria-label="Bar graph and table">
+				<TableChart />
+			</ToggleButton>
+			<ToggleButton value={ ViewType.scatterPlot } aria-label="Scatter plot">
+				<ScatterPlot />
+			</ToggleButton>
+		</ToggleButtonGroup>
 	);
 }
 

--- a/client/apps/analytics/src/components/stat-page/StatPage.tsx
+++ b/client/apps/analytics/src/components/stat-page/StatPage.tsx
@@ -58,6 +58,7 @@ function StatPage() {
 	const teamData: Team[] = useAppSelector(state => state.teams.data);
 	const stats: GlobalObjectiveStats[] = useAppSelector(state => state.stats.data);
 	const selectedStats: ObjectiveDescriptor[] = useAppSelector(state => state.stats.selectedStats);
+	const secondarySelectedStats: ObjectiveDescriptor[] = useAppSelector(state => state.stats.secondarySelectedStats);
 
 	const selectRobot = (robotNumber: number) => {
 		setSelectedRobotNumber(robotNumber);
@@ -146,7 +147,7 @@ function StatPage() {
 					<StatPlot
 						robots={ teamData }
 						horizontalObjectives={ selectedStats }
-						verticalObjectives={ selectedStats }
+						verticalObjectives={ secondarySelectedStats }
 						metric="mean"
 						selectRobot={ selectRobot }
 					/>
@@ -160,8 +161,10 @@ function StatPage() {
 			<main className="page stat-page">
 				<StatList
 					className="stat-list-wrapper"
+					variant={ viewType === ViewType.scatterPlot ? 'double' : 'single' }
 					stats={ stats }
 					selectedStats={ selectedStats }
+					secondarySelectedStats={ secondarySelectedStats }
 				/>
 				{ content }
 			</main>

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
@@ -7,21 +7,33 @@ import {
 } from '../../../models';
 import { useTranslator } from '../../../service/TranslateService';
 import StatListSection from './StatListSection';
-import { addSelectedStat, clearSelectedStats, removeSelectedStat, selectStat, useAppDispatch } from '../../../state';
+import {
+	addSecondarySelectedStat,
+	addSelectedStat,
+	clearSelectedStats,
+	removeSecondarySelectedStat,
+	removeSelectedStat,
+	selectStat,
+	useAppDispatch
+} from '../../../state';
 
 interface IProps {
 	className?: string;
+	variant: 'single' | 'double';
 	stats: GlobalObjectiveStats[];
 	selectedStats: ObjectiveDescriptor[];
+	secondarySelectedStats: ObjectiveDescriptor[];
 }
 
-export default function StatList({ className, stats, selectedStats }: IProps) {
+export default function StatList({ className, variant, stats, selectedStats, secondarySelectedStats }: IProps) {
 
 	const translate = useTranslator();
 	const dispatch = useAppDispatch();
 	const _setSelectedStat = (gamemode: string, objective: string) => dispatch(selectStat(gamemode, objective));
 	const _addSelectedStat = (gamemode: string, objective: string) => dispatch(addSelectedStat(gamemode, objective));
 	const _removeSelectedStat = (gamemode: string, objective: string) => dispatch(removeSelectedStat(gamemode, objective));
+	const _addSecondaryStat = (gamemode: string, objective: string) => dispatch(addSecondarySelectedStat(gamemode, objective));
+	const _removeSecondaryStat = (gamemode: string, objective: string) => dispatch(removeSecondarySelectedStat(gamemode, objective));
 	const _clearSelectedStats = () => dispatch(clearSelectedStats());
 
 	const statsGroupedByGamemode: Map<string, GlobalObjectiveStats[]> = new Map();
@@ -41,12 +53,16 @@ export default function StatList({ className, stats, selectedStats }: IProps) {
 			return (
 				<StatListSection
 					key={ gamemode }
+					variant={ variant }
 					gamemode={ gamemode }
 					stats={ objectives }
 					selectedStats={ selectedStats }
 					selectStat={(objective: string) => _setSelectedStat(gamemode, objective)}
 					addSelectedStat={ (objective: string) => _addSelectedStat(gamemode, objective) }
 					removeSelectedStat={ (objective: string) => _removeSelectedStat(gamemode, objective) }
+					secondarySelectedStats={ secondarySelectedStats }
+					addSecondarySelectedStat={ (objective: string) => _addSecondaryStat(gamemode, objective) }
+					removeSecondarySelectedStat={ (objective: string) => _removeSecondaryStat(gamemode, objective) }
 				/>
 			);
 		});

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
@@ -92,20 +92,17 @@ export default function StatListSection(props: IProps) {
 						onChange={ handleCheckboxClick }
 						onClick={ (event) => event.stopPropagation() }
 						style={{
-							opacity: props.selectedStats.length > 0 ? 1 : 0,
+							opacity: (props.selectedStats.length > 0 || props.variant === 'double') ? 1 : 0,
 							transition: 'opacity 150ms ease-in-out'
 						}}
 					/>
 					{ (props.variant === 'double') && (
 						<Checkbox
 							className="stat-list-checkbox"
+							color="secondary"
 							checked={ isSecondarySelected }
 							onChange={ handleSecondaryCheckboxClick }
 							onClick={ (event) => event.stopPropagation() }
-							style={{
-								opacity: props.selectedStats.length > 0 ? 1 : 0,
-								transition: 'opacity 150ms ease-in-out'
-							}}
 						/>
 					)}
 				</ListItemButton>

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
@@ -9,47 +9,67 @@ import { useTranslator } from '../../../service/TranslateService';
 import { roundToDecimal } from '../../../service/DisplayUtility';
 
 interface IProps {
+	variant: 'single' | 'double';
 	gamemode: string;
 	stats: GlobalObjectiveStats[];
 	selectedStats: ObjectiveDescriptor[];
 	selectStat: (objective: string) => void;
 	addSelectedStat: (objective: string) => void;
 	removeSelectedStat: (objective: string) => void;
+	secondarySelectedStats: ObjectiveDescriptor[];
+	addSecondarySelectedStat: (objective: string) => void;
+	removeSecondarySelectedStat: (objective: string) => void;
 }
 
-export default function StatListSection({ gamemode, stats, selectedStats, selectStat, addSelectedStat, removeSelectedStat }: IProps) {
+export default function StatListSection(props: IProps) {
 	const translate = useTranslator();
 
 	const descriptorToColorMap: Map<string, string> = useMemo(() => {
 		const map: Map<string, string> = new Map();
-		selectedStats.forEach((descriptor, index: number) => {
+		props.selectedStats.forEach((descriptor, index: number) => {
 			const key: string = descriptor.gamemode + '\0' + descriptor.objective;
 			map.set(key, STAT_GRAPH_COLORS[index % STAT_GRAPH_COLORS.length]);
 		});
 		return map;
-	}, [selectedStats]);
+	}, [props.selectedStats]);
 
-	const items = stats.map((stat: GlobalObjectiveStats) => {
-		const isSelected: boolean = !!selectedStats.find((descriptor: ObjectiveDescriptor) => (
+	const items = props.stats.map((stat: GlobalObjectiveStats) => {
+		const isSelected: boolean = !!props.selectedStats.find((descriptor: ObjectiveDescriptor) => (
 			descriptor.gamemode === stat.gamemode && descriptor.objective === stat.name
 		));
+
+		const isSecondarySelected: boolean =
+			props.variant === 'double'
+			&& !!props.secondarySelectedStats.find((descriptor: ObjectiveDescriptor) => (
+				descriptor.gamemode === stat.gamemode && descriptor.objective === stat.name
+			));
 
 		const handleCheckboxClick = (event): void => {
 			event.stopPropagation();
 
 			if (event.target.checked) {
-				addSelectedStat(stat.name);
+				props.addSelectedStat(stat.name);
 				return;
 			}
 
-			removeSelectedStat(stat.name);
+			props.removeSelectedStat(stat.name);
+		};
+
+		const handleSecondaryCheckboxClick = (event): void => {
+			event.stopPropagation();
+			if (event.target.checked) {
+				props.addSecondarySelectedStat(stat.name);
+				return;
+			}
+
+			props.removeSecondarySelectedStat(stat.name);
 		};
 
 		return (
 			<Fragment key={ stat.name }>
 				<ListItemButton
-					selected={ isSelected }
-					onClick={ () => selectStat(stat.name) }
+					selected={ isSelected || isSecondarySelected }
+					onClick={ () => props.selectStat(stat.name) }
 				>
 					<div className="stat-list-item">
 						<div>{ translate(stat.name) }</div>
@@ -57,7 +77,7 @@ export default function StatListSection({ gamemode, stats, selectedStats, select
 						<div>{ translate('MEDIAN') }: { roundToDecimal(stat.stats.median) }</div>
 					</div>
 					{
-						descriptorToColorMap.has(stat.gamemode + '\0' + stat.name) &&
+						(props.variant === 'single' && descriptorToColorMap.has(stat.gamemode + '\0' + stat.name)) &&
 						<div
 							className="stat-list-color-legend"
 							style={{
@@ -72,10 +92,22 @@ export default function StatListSection({ gamemode, stats, selectedStats, select
 						onChange={ handleCheckboxClick }
 						onClick={ (event) => event.stopPropagation() }
 						style={{
-							opacity: selectedStats.length > 0 ? 1 : 0,
+							opacity: props.selectedStats.length > 0 ? 1 : 0,
 							transition: 'opacity 150ms ease-in-out'
 						}}
 					/>
+					{ (props.variant === 'double') && (
+						<Checkbox
+							className="stat-list-checkbox"
+							checked={ isSecondarySelected }
+							onChange={ handleSecondaryCheckboxClick }
+							onClick={ (event) => event.stopPropagation() }
+							style={{
+								opacity: props.selectedStats.length > 0 ? 1 : 0,
+								transition: 'opacity 150ms ease-in-out'
+							}}
+						/>
+					)}
 				</ListItemButton>
 				<Divider variant="fullWidth" component="li"/>
 			</Fragment>
@@ -84,7 +116,7 @@ export default function StatListSection({ gamemode, stats, selectedStats, select
 
 	return (
 		<Fragment>
-			<ListSubheader style={{ top: 'var(--stat-header-height)' }}>{ translate(gamemode) }</ListSubheader>
+			<ListSubheader style={{ top: 'var(--stat-header-height)' }}>{ translate(props.gamemode) }</ListSubheader>
 			{ items }
 		</Fragment>
 	);

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
@@ -1,0 +1,17 @@
+.stat-plot {
+	position: relative;
+	display: flex;
+	flex-grow: 1;
+	border: 1px solid #dbdedf;
+	margin: 8px 24px 24px 24px;
+
+	&-point {
+		position: absolute;
+		width: 8px;
+		height: 8px;
+		background-color: #254999aa;
+		border: 1px solid #254999;
+		border-radius: 8px;
+		transform: translate(-50%, 50%);
+	}
+}

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
@@ -1,25 +1,46 @@
-.stat-plot {
-	position: relative;
-	display: flex;
+.stat-plot-wrapper {
+	display: grid;
 	flex-grow: 1;
-	border: 1px solid #dbdedf;
-	margin: 8px 24px 24px 24px;
-	padding: 16px;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: 1fr auto;
+	padding: 8px 24px 24px;
 
-	&-inner {
+	.stat-plot {
 		position: relative;
 		display: flex;
-		height: 100%;
-		width: 100%;
-	}
+		border: 1px solid #dbdedf;
+		padding: 16px;
 
-	&-point {
-		position: absolute;
-		width: 8px;
-		height: 8px;
-		background-color: #254999aa;
-		border: 1px solid #254999;
-		border-radius: 8px;
-		transform: translate(-50%, -50%);
+		&-horizontal-legend {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+
+		&-vertical-legend {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			writing-mode: vertical-lr;
+			transform: rotate(180deg);
+		}
+
+		&-inner {
+			position: relative;
+			display: flex;
+			height: 100%;
+			width: 100%;
+		}
+
+		&-point {
+			position: absolute;
+			width: 8px;
+			height: 8px;
+			background-color: #254999aa;
+			border: 1px solid #254999;
+			border-radius: 8px;
+			transform: translate(-50%, -50%);
+		}
 	}
 }
+

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
@@ -4,6 +4,14 @@
 	flex-grow: 1;
 	border: 1px solid #dbdedf;
 	margin: 8px 24px 24px 24px;
+	padding: 16px;
+
+	&-inner {
+		position: relative;
+		display: flex;
+		height: 100%;
+		width: 100%;
+	}
 
 	&-point {
 		position: absolute;
@@ -12,6 +20,6 @@
 		background-color: #254999aa;
 		border: 1px solid #254999;
 		border-radius: 8px;
-		transform: translate(-50%, 50%);
+		transform: translate(-50%, -50%);
 	}
 }

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.scss
@@ -1,28 +1,52 @@
 .stat-plot-wrapper {
 	display: grid;
 	flex-grow: 1;
+	grid-template-areas:
+		"vleg plot"
+		". hleg";
 	grid-template-columns: auto 1fr;
 	grid-template-rows: 1fr auto;
 	padding: 8px 24px 24px;
 
 	.stat-plot {
+		grid-area: plot;
 		position: relative;
 		display: flex;
 		border: 1px solid #dbdedf;
 		padding: 16px;
 
 		&-horizontal-legend {
+			grid-area: hleg;
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			column-gap: 4px;
+
+			&:before {
+				content: '';
+				width: 8px;
+				height: 8px;
+				border-radius: 4px;
+				background-color: #254999;
+			}
 		}
 
 		&-vertical-legend {
+			grid-area: vleg;
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			column-gap: 4px;
 			writing-mode: vertical-lr;
 			transform: rotate(180deg);
+
+			&:before {
+				content: '';
+				width: 8px;
+				height: 8px;
+				border-radius: 4px;
+				background-color: #ff9100;
+			}
 		}
 
 		&-inner {
@@ -34,12 +58,26 @@
 
 		&-point {
 			position: absolute;
+			box-sizing: border-box;
+			display: flex;
+			justify-content: center;
 			width: 8px;
 			height: 8px;
-			background-color: #254999aa;
+			padding: 0;
+			background-color: #25499988;
 			border: 1px solid #254999;
 			border-radius: 8px;
 			transform: translate(-50%, -50%);
+			cursor: pointer;
+
+			&-label {
+				position: absolute;
+				font-size: 12px;
+				line-height: 16px;
+				color: #000;
+				top: 0;
+				transform: translateY(-100%);
+			}
 		}
 	}
 }

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
@@ -57,7 +57,13 @@ export default function StatPlot(props: IProps) {
 
 	const points = props.robots.map(robot => (
 		<Tooltip
-			title={ robot.id }
+			title={(
+				<div>
+					<div>{ robot.id }</div>
+					<div>X:&nbsp;{ horizontalSums[robot.id].toFixed(2) }</div>
+					<div>Y:&nbsp;{ verticalSums[robot.id].toFixed(2) }</div>
+				</div>
+			)}
 			key={ robot.id }
 		>
 			<button

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
@@ -60,14 +60,16 @@ export default function StatPlot(props: IProps) {
 			title={ robot.id }
 			key={ robot.id }
 		>
-			<div
+			<button
 				className="stat-plot-point"
+				onClick={ () => props.selectRobot(robot.id) }
 				style={{
 					bottom: (verticalSums[robot.id] / maxVertical) * 100 + '%',
 					left: (horizontalSums[robot.id] / maxHorizontal) * 100 + '%',
 				}}
 			>
-			</div>
+				<span className="stat-plot-point-label">{ robot.id }</span>
+			</button>
 		</Tooltip>
 	));
 
@@ -79,7 +81,6 @@ export default function StatPlot(props: IProps) {
 					{ points }
 				</div>
 			</div>
-			<span></span>
 			<div className="stat-plot-horizontal-legend">Objectives</div>
 		</div>
 	);

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
@@ -1,0 +1,79 @@
+import './StatPlot.scss';
+import { Tooltip } from '@mui/material';
+import { useMemo } from 'react';
+import { ObjectiveDescriptor, Team, TeamObjectiveStats } from '../../../models';
+
+type MetricType = 'mean' | 'median' | 'mode';
+interface IProps {
+	robots: Team[];
+	horizontalObjectives: ObjectiveDescriptor[];
+	verticalObjectives: ObjectiveDescriptor[];
+	metric: MetricType;
+	selectRobot: (robotNumber: number) => void;
+}
+
+const getSumOfObjectives = (
+	robot: Team,
+	selectedObjectives: ObjectiveDescriptor[],
+	metric: MetricType
+): number => {
+	return selectedObjectives
+		.map((objective: ObjectiveDescriptor) => robot.stats.get(objective.gamemode)?.get(objective.objective))
+		.filter((stats: TeamObjectiveStats) => !!stats)
+		.map((stats: TeamObjectiveStats) => stats[metric])
+		.reduce((previous: number, current: number) => previous + current, 0);
+};
+
+const reduceToMax = (prev: number, current: number) => Math.max(prev, current);
+
+
+export default function StatPlot(props: IProps) {
+	const horizontalSums: Record<number, number> = useMemo(() => {
+		const result = {};
+		for (const robot of props.robots) {
+			result[robot.id] = getSumOfObjectives(robot, props.horizontalObjectives, props.metric);
+		}
+
+		return result;
+	}, [props.robots, props.horizontalObjectives, props.metric]);
+
+	const verticalSums: Record<number, number> = useMemo(() => {
+		const result = {};
+		for (const robot of props.robots) {
+			result[robot.id] = getSumOfObjectives(robot, props.verticalObjectives, props.metric);
+		}
+
+		return result;
+	}, [props.robots, props.verticalObjectives, props.metric]);
+
+	const maxHorizontal: number = useMemo(
+		() => Object.values(horizontalSums).reduce(reduceToMax),
+		[horizontalSums]
+	);
+	const maxVertical: number = useMemo(
+		() => Object.values(verticalSums).reduce(reduceToMax),
+		[verticalSums]
+	);
+
+	const points = props.robots.map(robot => (
+		<Tooltip
+			title={ robot.id }
+			key={ robot.id }
+		>
+			<div
+				className="stat-plot-point"
+				style={{
+					bottom: (verticalSums[robot.id] / maxVertical) * 100 + '%',
+					left: (horizontalSums[robot.id] / maxHorizontal) * 100 + '%',
+				}}
+			>
+			</div>
+		</Tooltip>
+	));
+
+	return (
+		<div className="stat-plot">
+			{ points }
+		</div>
+	);
+}

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
@@ -73,7 +73,9 @@ export default function StatPlot(props: IProps) {
 
 	return (
 		<div className="stat-plot">
-			{ points }
+			<div className="stat-plot-inner">
+				{ points }
+			</div>
 		</div>
 	);
 }

--- a/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-plot/StatPlot.tsx
@@ -72,10 +72,15 @@ export default function StatPlot(props: IProps) {
 	));
 
 	return (
-		<div className="stat-plot">
-			<div className="stat-plot-inner">
-				{ points }
+		<div className="stat-plot-wrapper">
+			<div className="stat-plot-vertical-legend">Objectives</div>
+			<div className="stat-plot">
+				<div className="stat-plot-inner">
+					{ points }
+				</div>
 			</div>
+			<span></span>
+			<div className="stat-plot-horizontal-legend">Objectives</div>
 		</div>
 	);
 }

--- a/client/apps/analytics/src/index.tsx
+++ b/client/apps/analytics/src/index.tsx
@@ -5,13 +5,26 @@ import { BrowserRouter } from 'react-router';
 import App from './components/App';
 import { store } from './state';
 import { myRegister, unregister } from './serviceWorkerRegistration';
+import { createTheme, ThemeProvider } from '@mui/material';
+import { orange } from '@mui/material/colors';
+
+const theme = createTheme({
+	palette: {
+		primary: {
+			main: '#254999'
+		},
+		secondary: orange
+	}
+});
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(
 	<Provider store={ store }>
 		<BrowserRouter>
-			<App/>
+			<ThemeProvider theme={theme}>
+				<App/>
+			</ThemeProvider>
 		</BrowserRouter>
 	</Provider>
 );

--- a/client/apps/analytics/src/models/src/states.model.ts
+++ b/client/apps/analytics/src/models/src/states.model.ts
@@ -58,6 +58,7 @@ export interface AppState {
 		loadStatus: LoadStatus;
 		data: GlobalObjectiveStats[];
 		selectedStats: ObjectiveDescriptor[];
+		secondarySelectedStats: ObjectiveDescriptor[];
 	};
 	planning: {
 		loadStatus: LoadStatus;

--- a/client/apps/analytics/src/state/Actions.ts
+++ b/client/apps/analytics/src/state/Actions.ts
@@ -48,6 +48,8 @@ export enum Actions {
 	SELECT_STAT = '[STATS] Select stat',
 	ADD_SELECTED_STAT = '[STATS] Add selection',
 	REMOVE_SELECTED_STAT = '[STATS] Remove selection',
+	ADD_SECONDARY_SELECTED_STAT = '[STATS] Add 2ary selection',
+	REMOVE_SECONDARY_SELECTED_STAT = '[STATS] Remove 2ary selection',
 	CLEAR_SELECTED_STATS = '[STATS] Clear selection',
 	SELECT_FIRST_TEAM_FOR_PLANNING = '[PLAN] Select first team',
 	SELECT_SECOND_TEAM_FOR_PLANNING = '[PLAN] Select second team',
@@ -223,6 +225,22 @@ export const addSelectedStat = (gamemode: string, objective: string): Action => 
 
 export const removeSelectedStat = (gamemode: string, objective: string): Action => ({
 	type: Actions.REMOVE_SELECTED_STAT,
+	payload: {
+		gamemode: gamemode,
+		objective: objective
+	}
+});
+
+export const addSecondarySelectedStat = (gamemode: string, objective: string): Action => ({
+	type: Actions.ADD_SECONDARY_SELECTED_STAT,
+	payload: {
+		gamemode: gamemode,
+		objective: objective
+	}
+});
+
+export const removeSecondarySelectedStat = (gamemode: string, objective: string): Action => ({
+	type: Actions.REMOVE_SECONDARY_SELECTED_STAT,
 	payload: {
 		gamemode: gamemode,
 		objective: objective

--- a/client/apps/analytics/src/state/Store.ts
+++ b/client/apps/analytics/src/state/Store.ts
@@ -42,7 +42,8 @@ const INITIAL_STATE: AppState = {
 	stats: {
 		loadStatus: LoadStatus.none,
 		data: [],
-		selectedStats: []
+		selectedStats: [],
+		secondarySelectedStats: []
 	},
 	planning: {
 		loadStatus: LoadStatus.none,
@@ -358,12 +359,31 @@ const mainReducer = function (state: AppState = INITIAL_STATE, action: Action): 
 					))
 				}
 			};
+		case Actions.ADD_SECONDARY_SELECTED_STAT:
+			return {
+				...state,
+				stats: {
+					...state.stats,
+					secondarySelectedStats: state.stats.secondarySelectedStats.concat(action.payload)
+				}
+			};
+		case Actions.REMOVE_SECONDARY_SELECTED_STAT:
+			return {
+				...state,
+				stats: {
+					...state.stats,
+					secondarySelectedStats: state.stats.secondarySelectedStats.filter((descriptor) => (
+						!(descriptor.gamemode === action.payload.gamemode && descriptor.objective === action.payload.objective)
+					))
+				}
+			};
 		case Actions.CLEAR_SELECTED_STATS:
 			return {
 				...state,
 				stats: {
 					...state.stats,
-					selectedStats: []
+					selectedStats: [],
+					secondarySelectedStats: []
 				}
 			};
 		case Actions.SELECT_FIRST_TEAM_FOR_PLANNING:


### PR DESCRIPTION
Add a "bubble graph" like that from Statbotics

It adds a fourth view selection to the Stats page. When this view is chosen, the user can add objectives to one of two groups. The counts from each objective are summed into the group total. One group represents the X axis, and the other represents the Y axis.

Teams are displayed within the graph as a small point, whose position is determined by the team's objective sums relative to that of the highest performing team on each axis.

Like the bar chart, clicking on a team's bubble will open a modal with the team's detail view.

This update also sets the primary color palette to match the blue color used in the bar graphs, and the secondary color to match the Material "orange" color.

![image](https://github.com/user-attachments/assets/aa19b05c-28f2-4f52-9f36-7074960d5a19)
