### PR TITLE
Stat Page Color Filtering

### DIFF
--- a/client/apps/analytics/src/components/stat-page/StatPage.scss
+++ b/client/apps/analytics/src/components/stat-page/StatPage.scss
@@ -28,6 +28,12 @@
 			align-items: flex-end;
 			justify-content: space-between;
 			padding: 16px $side-padding 0 $side-padding;
+
+			.view-picker {
+				display: flex;
+				flex-direction: row;
+				gap: 8px;
+			}
 		}
 
 		.stat-content-title {

--- a/client/apps/analytics/src/components/stat-page/filter-picker/FilterPicker.scss
+++ b/client/apps/analytics/src/components/stat-page/filter-picker/FilterPicker.scss
@@ -1,0 +1,5 @@
+.filter-picker {
+    display: flex;
+    flex-direction: row;
+    column-gap: 8px;
+}

--- a/client/apps/analytics/src/components/stat-page/filter-picker/FilterPicker.tsx
+++ b/client/apps/analytics/src/components/stat-page/filter-picker/FilterPicker.tsx
@@ -1,0 +1,181 @@
+import { AssignmentTurnedIn, BarChart, EditNote, Timeline } from "@mui/icons-material";
+import { MenuItem, Select, SelectChangeEvent, TextField, ToggleButton, ToggleButtonGroup, Tooltip } from "@mui/material";
+import { StatsFilter, ViewType, StatsFilterType } from "../../../models";
+import TranslatedPicker from "./translated-picker/TranslatedPicker";
+import './FilterPicker.scss';
+import { useTranslator } from '../../../service/TranslateService';
+import { useAppSelector } from '../../../state';
+import { LoadStatus } from '@gearscout/models';
+
+interface IProps {
+    viewType: ViewType;
+    inspectionQuestions: string[];
+    commentTopics: string[];
+    statTopics: string[];
+    filter: StatsFilter;
+    selectFilter: (filter: StatsFilter) => void;
+}
+
+function FilterPicker(props: IProps) {
+    const translate = useTranslator();
+
+    const statsLoadStatus: LoadStatus = useAppSelector(state => state.stats.loadStatus);
+    const inspectionsLoadStatus: LoadStatus = useAppSelector(state => state.inspections.loadStatus);
+    const commentsLoadStatus: LoadStatus = useAppSelector(state => state.comments.loadStatus);
+
+
+    const showStatsPicker = statsLoadStatus === LoadStatus.success
+        && props.filter.filterType === StatsFilterType.stats;
+    const showInspectionsPicker = inspectionsLoadStatus === LoadStatus.success
+        && props.filter.filterType === StatsFilterType.inspection;
+    const showCommentsPicker = commentsLoadStatus === LoadStatus.success
+        && props.filter.filterType === StatsFilterType.comments;
+
+
+    const showComentsQuery = showCommentsPicker
+        && props.filter.topic !== '';
+
+
+    return (
+        <div className="filter-picker">
+            { showComentsQuery && commentsQuery(props, translate) }
+
+            { showStatsPicker && statsPicker(props) }
+            { showInspectionsPicker && inspectionPicker(props) }
+            { showCommentsPicker && commentsPicker(props) }
+
+            <ToggleButtonGroup
+                size="small"
+                exclusive={ true }
+                value={ props.filter.filterType }
+                onChange={ (_, next: StatsFilterType) => {
+                    if (next == undefined || next === props.filter.filterType) {
+                        return;
+                    }
+
+                    props.selectFilter({
+                        filterType: next,
+                        topic: '',
+                        query: ''
+                    });
+                }}
+                aria-label="Data filter type"
+                sx={{ display: 'block', marginBottom: '8px' }}
+            >
+                <ToggleButton
+                    value={ StatsFilterType.none }
+                    aria-label="No data filtering"
+                >
+                    <BarChart/>
+                </ToggleButton>
+
+                { inspectionsLoadStatus === LoadStatus.success && (
+                    <Tooltip title={ translate('INSPECTIONS') }>
+                        <ToggleButton
+                            value={ StatsFilterType.inspection }
+                            aria-label="Filter by inspection"
+                        >
+                            <AssignmentTurnedIn/>
+                        </ToggleButton>
+                    </Tooltip>
+                )}
+
+                { statsLoadStatus === LoadStatus.success && (
+                    <Tooltip title={ translate('STATS') }>
+                        <ToggleButton
+                            value={ StatsFilterType.stats }
+                            aria-label="Filter by stats"
+                        >
+                            <Timeline/>
+                        </ToggleButton>
+                    </Tooltip>
+                )}
+
+                { commentsLoadStatus === LoadStatus.success && (
+                    <Tooltip title={ translate('NOTES') }>
+                        <ToggleButton
+                            value={ StatsFilterType.comments }
+                            aria-label="Filter by notes"
+                        >
+                            <EditNote/>
+                        </ToggleButton>
+                    </Tooltip>
+                )}
+            </ToggleButtonGroup>
+
+            
+        </div>
+    );
+}
+
+function statsPicker(props: IProps) {
+    return (
+        <Select
+            size="small"
+            value={ props.filter.topic }
+            onChange={ (event: SelectChangeEvent) => {
+                props.selectFilter({
+                    ...props.filter,
+                    topic: event.target.value
+                })
+            }}
+            aria-label="Filter type"
+            sx={{ display: 'block', marginBottom: '8px' }}
+        >
+            {
+                props.statTopics.map((option) => (
+                    <MenuItem value={option}>{option}</MenuItem>
+                ))
+            }
+        </Select>
+    )
+}
+
+function inspectionPicker(props: IProps) {
+    return (
+        <TranslatedPicker
+            options={ props.inspectionQuestions }
+            selected={ props.filter.topic }
+            setSelected={ (next: string) => {
+                props.selectFilter({
+                    ...props.filter,
+                    topic: next
+                });
+            }}
+        />
+    )
+}
+
+function commentsPicker(props: IProps) {
+    return (
+        <TranslatedPicker
+            options={ props.commentTopics }
+            selected={ props.filter.topic }
+            setSelected={ (next: string) => {
+                props.selectFilter({
+                    ...props.filter,
+                    topic: next
+                });
+            }}
+        />
+    )
+}
+
+function commentsQuery(props: IProps, translate: (key: string) => string) {
+    return (
+        <TextField
+            variant="outlined"
+            size="small"
+            placeholder={ translate('SEARCH') }
+            onChange={ (event) => {
+                console.log(event.target.value);
+                props.selectFilter({
+                    ...props.filter,
+                    query: event.target.value
+                });
+            }}
+        />
+    )
+}
+
+export default FilterPicker;

--- a/client/apps/analytics/src/components/stat-page/filter-picker/translated-picker/TranslatedPicker.tsx
+++ b/client/apps/analytics/src/components/stat-page/filter-picker/translated-picker/TranslatedPicker.tsx
@@ -1,0 +1,48 @@
+import { useTranslator } from '../../../../service/TranslateService';
+import {
+	MenuItem,
+	Select,
+	SelectChangeEvent,
+} from '@mui/material';
+
+interface IProps {
+	selected: string;
+	options: string[];
+	setSelected: (option: string) => void;
+}
+
+function TranslatedPicker(props: IProps) {
+	const translate = useTranslator();
+
+	const sortedOptions = props.options.toSorted();
+
+	const reverseTranslations = Object.fromEntries(
+		sortedOptions.map((opt) => [translate(opt), opt])
+	);
+
+	return (
+		<Select
+			size="small"
+			value={ translate(props.selected) || '' }
+			onChange={ (event: SelectChangeEvent) => {
+				const next = reverseTranslations[event.target.value];
+				if (next != undefined) {
+					props.setSelected(next);
+				}
+			}}
+			aria-label="Filter type"
+			sx={{ display: 'block', marginBottom: '8px' }}
+		>
+			{
+				sortedOptions.map((option) => (
+					<MenuItem value={ translate(option) }>
+						{ translate(option) }
+					</MenuItem>
+				))
+			}
+		</Select>
+	);
+}
+
+
+export default TranslatedPicker;

--- a/client/apps/analytics/src/components/stat-page/stat-graph-colored/StatGraphColored.scss
+++ b/client/apps/analytics/src/components/stat-page/stat-graph-colored/StatGraphColored.scss
@@ -1,0 +1,60 @@
+
+.stat-graph-stacked {
+	display: flex;
+	flex-direction: column;
+	overflow-x: auto;
+	padding: 0 24px 16px 24px;
+
+	&.reduced-height {
+		min-height: min(63%, 420px);
+	}
+
+	&.full-height {
+		height: 100%;
+	}
+
+	.content {
+		display: flex;
+		flex-direction: row;
+		height: 100%;
+		width: fit-content;
+		padding-left: 4px;
+		padding-right: 4px;
+
+		box-sizing: border-box;
+		border: 1px solid var(--border-color);
+		border-radius: 4px;
+
+		.team-bars {
+			display: flex;
+			flex-direction: column-reverse;
+
+			.bar {
+				width: 40px;
+				min-width: 40px;
+				margin-left: 4px;
+				margin-right: 4px;
+				background-color: #aa2456;
+			}
+		}
+	}
+
+	.team-number-wrapper {
+		display: flex;
+		flex-direction: row;
+		padding-left: 4px;
+		padding-right: 4px;
+
+		.team-number {
+			text-align: center;
+			min-width: 40px;
+			margin-left: 4px;
+			margin-right: 4px
+		}
+	}
+}
+
+.tip-divider {
+	color: white;
+	background-color: white;
+}

--- a/client/apps/analytics/src/components/stat-page/stat-graph-colored/StatGraphColored.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-graph-colored/StatGraphColored.tsx
@@ -1,0 +1,112 @@
+import './StatGraphColored.scss';
+import { STAT_GRAPH_COLOR_SCALE_UNKNOWN, ObjectiveDescriptor, StatsFilter, Team, TeamObjectiveStats, GraphColoring, BarAttributes } from '../../../models';
+import { useTranslator } from '../../../service/TranslateService';
+import { Tooltip } from '@mui/material';
+import { roundToDecimal } from '../../../service/DisplayUtility';
+
+type MetricType = 'mean' | 'median' | 'mode';
+type Height = 'full' | 'reduced';
+
+
+interface IProps {
+	robots: Team[];
+	selectedObjectives: ObjectiveDescriptor[];
+	filter: StatsFilter,
+	coloring: GraphColoring,
+	metric: MetricType;
+	height: Height;
+	selectRobot: (robotNumber: number) => void;
+}
+
+const getSumOfObjectives = (
+	robot: Team,
+	selectedObjectives: ObjectiveDescriptor[],
+	metric: MetricType
+): number => {
+	return selectedObjectives
+		.map((objective: ObjectiveDescriptor) => robot.stats.get(objective.gamemode)?.get(objective.objective))
+		.filter((stats: TeamObjectiveStats) => !!stats)
+		.map((stats: TeamObjectiveStats) => stats[metric])
+		.reduce((previous: number, current: number) => previous + current, 0);
+};
+
+const compareByObjectiveSum = (
+	a: Team,
+	b: Team,
+	selectedObjectives: ObjectiveDescriptor[],
+	metric: MetricType
+): number => {
+	return getSumOfObjectives(b, selectedObjectives, metric) - getSumOfObjectives(a, selectedObjectives, metric);
+};
+
+export default function StatGraphColored(props: IProps) {
+	const translate = useTranslator();
+
+	const sortedRobots: Team[] = props.robots.slice()
+		.sort((a: Team, b: Team) => compareByObjectiveSum(a, b, props.selectedObjectives, props.metric));
+	const maxScore: number = getSumOfObjectives(sortedRobots[0], props.selectedObjectives, props.metric);
+
+	const teamLabels = sortedRobots.map(createTeamLabel);
+
+	const teamBars = sortedRobots
+		.map((robot: Team) => {
+			return createBar(props, robot, maxScore, translate);
+		});
+
+	return (
+		<div className={ 'stat-graph-stacked ' + props.height + '-height' }>
+			<div className="content">{ teamBars }</div>
+			<div className="team-number-wrapper">{ teamLabels}</div>
+		</div>
+	);
+}
+
+const createTeamLabel = (robot: Team) => {
+	return (
+		<div key={ robot.id } className="team-number">
+			{ robot.id }
+		</div>
+	);
+};
+
+const createBar = (
+	props: IProps,
+	robot: Team,
+	maxScore: number,
+	translate: (key: string) => string
+) => {
+	const scoreSum: number = getSumOfObjectives(robot, props.selectedObjectives, props.metric);
+
+	const elementKey: string = `${robot.id}`;
+	const attributes: BarAttributes = props.coloring.attributes[robot.id];
+
+	const barStyle = {
+		height: 100 * scoreSum / maxScore + '%',
+		backgroundColor: attributes?.color || STAT_GRAPH_COLOR_SCALE_UNKNOWN
+	};
+
+	const label = attributes?.label;
+
+	const tooltipContent = (
+		<div>
+			<div>{ translate('TEAM') }:&nbsp;{ robot.id }</div>
+			<div>{ translate('TOTAL') }:&nbsp;{ roundToDecimal(scoreSum) }</div>
+			<hr className="tip-divider"/>
+			{(label != undefined && label != '') && (
+				<div>{ `${translate(props.filter.topic)}: ${label}` }</div>
+			)}
+		</div>
+	);
+
+	return (
+		<Tooltip
+			key={ robot.id }
+			title={ tooltipContent }
+			arrow={ true }
+		>
+			<div key={ robot.id } className="team-bars" onClick={ () => props.selectRobot(robot.id) }>
+				<div key={ elementKey } className="bar" style={ barStyle } />
+			</div>
+		</Tooltip>
+	);
+}

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatList.tsx
@@ -19,7 +19,7 @@ import {
 
 interface IProps {
 	className?: string;
-	variant: 'single' | 'double';
+	variant: 'single' | 'single-nokey' | 'double';
 	stats: GlobalObjectiveStats[];
 	selectedStats: ObjectiveDescriptor[];
 	secondarySelectedStats: ObjectiveDescriptor[];

--- a/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
+++ b/client/apps/analytics/src/components/stat-page/stat-list/StatListSection.tsx
@@ -9,7 +9,7 @@ import { useTranslator } from '../../../service/TranslateService';
 import { roundToDecimal } from '../../../service/DisplayUtility';
 
 interface IProps {
-	variant: 'single' | 'double';
+	variant: 'single' | 'single-nokey' | 'double';
 	gamemode: string;
 	stats: GlobalObjectiveStats[];
 	selectedStats: ObjectiveDescriptor[];

--- a/client/apps/analytics/src/models/src/constants.model.tsx
+++ b/client/apps/analytics/src/models/src/constants.model.tsx
@@ -20,9 +20,26 @@ export const superchargeGridScoreConfig: GridScoreConfig = {
 export const STAT_GRAPH_COLORS: string[] = [
 	'#254999',
 	'#dd8850',
-	'#884099',
-	'#44ac88'
+	'#704099',
+	'#44ab52'
 ];
+
+export const STAT_GRAPH_COLOR_SCALE_1: string[] = [
+    '#ffe532',
+    '#d2da9a',
+    '#bbcbac',
+    '#a6bbb4',
+    '#93abb7',
+    '#829bb8',
+    '#718cb6',
+    '#607db3',
+    '#4f6daf',
+    '#3d5faa',
+    '#2750a4',
+	'#00429d',
+]
+
+export const STAT_GRAPH_COLOR_SCALE_UNKNOWN: string = '#aaaaaa';
 
 export const GAMEMODE_ORDERING: Record<string, string> = {
 	'AUTO': '0',

--- a/client/apps/analytics/src/models/src/states.model.ts
+++ b/client/apps/analytics/src/models/src/states.model.ts
@@ -34,6 +34,20 @@ export enum LoginStatus {
 	logInFailed = 'logInFailed',
 }
 
+export enum StatsFilterType {
+	none = 'none',
+	inspection = 'inspection',
+	comments = 'comments',
+	stats = 'stats',
+}
+
+export enum ViewType {
+	barGraph = 'barGraph',
+	table = 'table',
+	barGraphTable = 'barGraphTable',
+	scatterPlot = 'scatterPlot',
+}
+
 export interface AppState {
 	language: Language;
 	loginV2: LoginV2State;
@@ -109,4 +123,22 @@ export interface CommentState {
 export interface IUserManagementState {
 	loadStatus: LoadStatus;
 	users: IUserInfo[];
+}
+
+export interface StatsFilter {
+	filterType: StatsFilterType,
+	topic: string,
+	query: string
+}
+
+export interface BarAttributes {
+	color: string;
+	label: string;
+}
+
+export interface GraphColoring {
+	// map of teams to bar properties
+	attributes: {[k: string]: BarAttributes};
+	// map of attributes to colors
+	legend: {[k: string]: string};
 }


### PR DESCRIPTION
Add a new button set to the stats page, which looks like this:

![qscrot-250423-160753](https://github.com/user-attachments/assets/1917b46a-2140-4861-b144-b8697f90896c)

This allows you to toggle the bar graph between four different modes:

- Color coded stacked bar (same as it does now)
- Color coded based on pit scouting data
- Color coded based on stats (quant and super)
- Color coded based on notes

Disregard the weird artifacts in the screenshots, that's my screenshot tool being dumb.

# Default mode

This mode is the thing GearScout already does. Carry on.

![qscrot-250423-160759](https://github.com/user-attachments/assets/19e47747-cb6f-450d-b2cb-4caf891bd1b1)

# Pit Scouting Color Coding

The second mode allows you to color the bar graph based on pit scouting data.

Numeric pit scouting data uses a colorblind-friendly blue-to-yellow color gradient:

![qscrot-250423-160818](https://github.com/user-attachments/assets/f43dde01-d6b5-4f73-b748-68d34032d3f8)

Non-numeric pit scouting data gets put into buckets:

![qscrot-250423-161525](https://github.com/user-attachments/assets/1076aa79-f484-424c-82af-de4ff754488e)

# Stats Color Coding

The third mode lets you color the bar graph based on one statistic, be it superscouting or quantitative data. This uses the same blue-to-yellow scale from earlier:

![qscrot-250423-160852](https://github.com/user-attachments/assets/44ecbf1d-e7ad-42be-924a-e4e62f2e5566)

# Notes Color Coding

The fourth mode lets you color the bar graph based on notes. Initially, robots without notes for the selected category will be gray, and all robots with notes for the selected category will be blue:

![qscrot-250423-160912](https://github.com/user-attachments/assets/e75bf509-2b2b-499c-94ae-e0e0be34874b)

When you add a search query, robots with notes matching the query remain blue, while robots whose notes don't match the query turn orange:

![qscrot-250423-162345](https://github.com/user-attachments/assets/70469d75-d89f-4cf9-81a0-9885befaccbc)

Multiple queries can be supplied by separating them with commas:

![qscrot-250423-162527](https://github.com/user-attachments/assets/e911fb46-64b8-4c83-bb27-c19aaa8d8237)
