### PR TITLE
Add backend support for cross-team collaboration

### DIFF
--- a/src/main/java/team/gif/gearscout/events/EventEntity.java
+++ b/src/main/java/team/gif/gearscout/events/EventEntity.java
@@ -47,6 +47,8 @@ public class EventEntity {
 	@SecretCodeConstraint
 	private String secretCode;
 
+	@Column(nullable = false)
+	private boolean shared;
 
 	public EventEntity() {}
 
@@ -82,6 +84,10 @@ public class EventEntity {
 		return secretCode;
 	}
 
+	public boolean isShared() {
+		return shared;
+	}
+
 	public void setId(Long id) {
 		this.id = id;
 	}
@@ -102,5 +108,7 @@ public class EventEntity {
 		this.secretCode = secretCode;
 	}
 
-
+	public void setShared(boolean shared) {
+		this.shared = shared;
+	}
 }

--- a/src/main/java/team/gif/gearscout/events/EventRepository.java
+++ b/src/main/java/team/gif/gearscout/events/EventRepository.java
@@ -31,4 +31,17 @@ public interface EventRepository extends CrudRepository<EventEntity, Long> {
 	""")
 	List<EventEntity> getEventEntitiesByTeamNumber(Integer teamNumber);
 
+	@Query(value = """
+	SELECT event
+	FROM EventEntity event
+	WHERE event.gameYear = :gameYear
+		AND event.eventCode = :eventCode
+		AND event.secretCode = :secretCode
+		AND event.shared = TRUE
+	""")
+	List<EventEntity> findSharedEvents(
+		Integer gameYear,
+		String eventCode,
+		String secretCode
+	);
 }

--- a/src/main/java/team/gif/gearscout/events/EventService.java
+++ b/src/main/java/team/gif/gearscout/events/EventService.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Isolation;
 import team.gif.gearscout.inspections.InspectionRepository;
 import team.gif.gearscout.matches.MatchRepository;
 import team.gif.gearscout.shared.EventInfo;
@@ -31,6 +33,7 @@ public class EventService {
 		this.eventRepository = eventRepository;
 	}
 
+	@Transactional(isolation = Isolation.SERIALIZABLE)
 	public EventEntity getOrCreateEvent(Integer teamNumber, Integer gameYear, String eventCode, String secretCode) {
 		Optional<EventEntity> eventEntity = eventRepository.findByEventDescriptor(teamNumber, gameYear, eventCode, secretCode);
 		return eventEntity.orElseGet(
@@ -38,10 +41,23 @@ public class EventService {
 		);
 	}
 
+	public List<EventEntity> getSharedEvents(EventEntity eventEntity) {
+		return eventRepository.findSharedEvents(
+			eventEntity.getGameYear(),
+			eventEntity.getEventCode(),
+			eventEntity.getSecretCode()
+		);
+	}
+
 	public EventEntity getEvent(Long eventId) {
 		return eventRepository
 			.findById(eventId)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+	}
+
+	public void setEventShared(EventEntity event, boolean shared) {
+		event.setShared(shared);
+		eventRepository.save(event);
 	}
 
 	public List<AggregateEventInfo> getEventList(Integer teamNumber) {

--- a/src/main/java/team/gif/gearscout/matches/MatchRepository.java
+++ b/src/main/java/team/gif/gearscout/matches/MatchRepository.java
@@ -13,10 +13,10 @@ public interface MatchRepository extends CrudRepository<MatchEntity, Long> {
 	SELECT match
 	FROM MatchEntity match
 	JOIN FETCH match.objectives
-	WHERE match.eventId = :eventId
+	WHERE match.eventId IN :eventIds
 	ORDER BY match.matchNumber, match.robotNumber, match.timeCreated ASC
 	""")
-	List<MatchEntity> findMatchesByEventId(Long eventId);
+	List<MatchEntity> findMatchesByEventIds(List<Long> eventIds);
 
 	@Query(value = """
 	SELECT match

--- a/src/main/java/team/gif/gearscout/matches/MatchService.java
+++ b/src/main/java/team/gif/gearscout/matches/MatchService.java
@@ -2,6 +2,7 @@ package team.gif.gearscout.matches;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import team.gif.gearscout.events.EventEntity;
 import team.gif.gearscout.matches.model.MatchEntity;
 import team.gif.gearscout.matches.model.CreateMatchRequest;
 import team.gif.gearscout.matches.model.ObjectiveEntity;
@@ -46,12 +47,11 @@ public class MatchService {
 		// Convert Match to MatchEntity
 		String currentTime = Long.toString(System.currentTimeMillis());
 		MatchEntity matchEntity = new MatchEntity(eventId, match, teamNumber, currentTime);
-		
 		return matchRepository.save(matchEntity);
 	}
-	
-	public List<MatchEntity> getAllMatchesForEvent(Long eventId) {
-		return matchRepository.findMatchesByEventId(eventId);
+
+	public List<MatchEntity> getAllMatchesForEvents(List<Long> eventIds) {
+		return matchRepository.findMatchesByEventIds(eventIds);
 	}
 
 	public MatchEntity getMatch(Long matchId) {

--- a/src/main/java/team/gif/gearscout/matches/controller/GuestMatchController.java
+++ b/src/main/java/team/gif/gearscout/matches/controller/GuestMatchController.java
@@ -73,11 +73,16 @@ public class GuestMatchController {
 	) {
 		logger.debug("Received getAllMatchesForEvent request: {}, {}", teamNumber, eventCode);
 
-		Long eventId = eventService
-			.getOrCreateEvent(teamNumber, gameYear, eventCode, secretCode)
-			.getId();
-		List<MatchEntity> result = matchService.getAllMatchesForEvent(eventId);
-		
+		EventEntity event = eventService
+			.getOrCreateEvent(teamNumber, gameYear, eventCode, secretCode);
+
+		// You don't get to benefit from shared data if you aren't sharing your own data
+		List<Long> eventIds = event.isShared()
+			? eventService.getSharedEvents(event).stream().map(EventEntity::getId).toList()
+			: List.of(event.getId());
+
+		List<MatchEntity> result = matchService.getAllMatchesForEvents(eventIds);
+
 		return ResponseEntity.ok(result);
 	}
 

--- a/src/main/resources/db/baseline/B16__baseline.sql
+++ b/src/main/resources/db/baseline/B16__baseline.sql
@@ -1,0 +1,219 @@
+-- This file is not actually processed by Flyway
+-- I just put it here to show what the baseline currently is
+-- If I need to add a new baseline schema to Flyway,
+-- I can just copy this one to the `migrations` folder
+
+CREATE SEQUENCE IF NOT EXISTS hibernate_sequence
+	START WITH 1
+	INCREMENT BY 1
+;
+
+
+CREATE SEQUENCE IF NOT EXISTS events_seq
+	START WITH 1
+	INCREMENT BY 1
+;
+CREATE TABLE IF NOT EXISTS events (
+	id			bigint		NOT NULL,
+	team_number	integer		NOT NULL,
+	game_year	integer		NOT NULL,
+	event_code	varchar(32)	NOT NULL,
+	secret_code	varchar(32)	NOT NULL,
+	shared		boolean		NOT NULL DEFAULT false,
+	CONSTRAINT events_pkey PRIMARY KEY (id),
+	CONSTRAINT chk_events_min_team_number CHECK (team_number >= 0),
+	CONSTRAINT chk_events_min_game_year CHECK (game_year >= 1995)
+);
+CREATE INDEX IF NOT EXISTS idx__events__info
+	ON events
+	USING btree (team_number, game_year, event_code, secret_code)
+;
+
+
+CREATE SEQUENCE IF NOT EXISTS matches_seq
+	START WITH 1
+	INCREMENT BY 1
+;
+CREATE TABLE IF NOT EXISTS matches (
+	id				bigint		NOT NULL,
+	event_id		bigint		NOT NULL,
+	team_number		integer		NOT NULL,
+	game_year		integer		NOT NULL,
+	creator			varchar(32)	NOT NULL,
+	match_number	integer		NOT NULL,
+	robot_number	integer		NOT NULL,
+	alliance_color	varchar(32),
+	time_created	varchar(32)	NOT NULL,
+	is_hidden		boolean		NOT NULL,
+	CONSTRAINT matches_pkey PRIMARY KEY (id),
+	CONSTRAINT fk__matches__event_id FOREIGN KEY (event_id)
+		REFERENCES events (id)
+		ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx__matches__event_id
+	ON matches
+	USING btree (event_id)
+;
+
+
+CREATE SEQUENCE IF NOT EXISTS objectives_seq
+	START WITH 1
+	INCREMENT BY 1
+;
+CREATE TABLE IF NOT EXISTS objectives (
+	id			bigint		NOT NULL,
+	match_id	bigint,					-- TODO: want it to be non-null, but every row is null
+	gamemode	varchar(32)	NOT NULL,
+	objective	varchar(64)	NOT NULL,	-- TODO: decrease size?
+	count		integer		NOT NULL,
+	list		integer[],
+	CONSTRAINT objectives_pkey PRIMARY KEY (id),
+	CONSTRAINT fk__objective__match_id FOREIGN KEY (match_id)
+		REFERENCES matches (id)
+		ON DELETE CASCADE
+);
+
+
+CREATE TABLE IF NOT EXISTS matches_objectives (
+	match_entity_id	bigint	NOT NULL,
+	objectives_id	bigint	NOT NULL,
+	CONSTRAINT fk__matches_objectives__objective_id FOREIGN KEY (objectives_id)
+		REFERENCES objectives (id)
+		ON DELETE CASCADE,
+	CONSTRAINT fk__matches_objectives__match_id FOREIGN KEY (match_entity_id)
+		REFERENCES matches (id)
+		ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx__match_obj__match_id
+	ON matches_objectives
+	USING btree (match_entity_id)
+;
+
+
+CREATE SEQUENCE IF NOT EXISTS image_info_seq
+	START WITH 1
+	INCREMENT BY 1
+;
+CREATE TABLE IF NOT EXISTS image_info (
+	id				bigint		NOT NULL,
+	event_id		bigint		NOT NULL,
+	team_number		integer		NOT NULL,
+	game_year		integer		NOT NULL,
+	robot_number	integer		NOT NULL,
+	creator			varchar(32)	NOT NULL,
+	time_created	varchar(32)	NOT NULL,
+	image_id		uuid		NOT NULL,
+	CONSTRAINT image_info_pkey PRIMARY KEY (id),
+	CONSTRAINT fk__image_info__event_id FOREIGN KEY (event_id)
+		REFERENCES events (id)
+		ON DELETE CASCADE
+	-- TODO: Add foreign key constraint image_id -> image_content.id?
+);
+CREATE INDEX IF NOT EXISTS idx__image_info__event_id
+	ON image_info
+	USING btree (event_id)
+;
+
+
+CREATE TABLE IF NOT EXISTS image_content (
+	id				uuid		NOT NULL DEFAULT gen_random_uuid(),
+	content_type	varchar(32)	NOT NULL,
+	content			bytea		NOT NULL,
+	CONSTRAINT image_content_pkey PRIMARY KEY (id)
+);
+
+
+-- TODO: Increase increment size to make mass inserts more efficient
+-- TODO: Add `unique` constraint on (event_id, robot_number, question)?
+-- TODO: Separate into two tables: forms, questions
+CREATE SEQUENCE detail_notes_seq
+	START WITH 1
+	INCREMENT BY 1
+;
+CREATE TABLE detail_notes (
+	id				bigint			NOT NULL,
+	event_id		bigint			NOT NULL,
+	team_number		integer			NOT NULL,
+	game_year		integer			NOT NULL,
+	robot_number	integer			NOT NULL,
+	question		varchar(32)		NOT NULL,
+	answer			varchar(1024)	NOT NULL,
+	creator			varchar(32)		NOT NULL,
+	time_created	varchar(32)		NOT NULL,
+	CONSTRAINT detail_notes_pkey PRIMARY KEY (id),
+	CONSTRAINT fk__detail_notes__event_id FOREIGN KEY (event_id)
+		REFERENCES events (id)
+		ON DELETE CASCADE,
+	CONSTRAINT chk_detail_notes_min_robot_number CHECK (robot_number >= 0)
+);
+CREATE INDEX IF NOT EXISTS idx__inspections__event_id
+	ON detail_notes
+	USING btree (event_id)
+;
+
+
+CREATE SEQUENCE comments_seq
+	START WITH 1
+	INCREMENT BY 1
+;
+CREATE TABLE comments (
+	id				bigint		NOT NULL,
+	event_id		bigint		NOT NULL,
+	team_number		integer		NOT NULL,
+	game_year		integer		NOT NULL,
+	robot_number	integer		NOT NULL,
+	match_number	integer		NOT NULL,
+	topic			varchar(32)	NOT NULL,
+	content			varchar(1024)	NOT NULL,
+	creator			varchar(32)	NOT NULL,
+	time_created timestamp(0) with time zone NOT NULL,
+	CONSTRAINT comments_pkey PRIMARY KEY (id),
+	CONSTRAINT fk__comments__event_id FOREIGN KEY (event_id)
+		REFERENCES events (id)
+		ON DELETE CASCADE,
+	CONSTRAINT chk_comments_min_robot_number CHECK (robot_number >= 0),
+	CONSTRAINT chk_comments_min_match_number CHECK (match_number >= 0)
+);
+CREATE INDEX IF NOT EXISTS idx__comments__event_id
+	ON comments
+	USING btree (event_id)
+;
+
+
+CREATE SEQUENCE users_seq
+	START WITH 1
+	INCREMENT BY 5
+;
+CREATE TABLE users (
+	user_id		bigint			NOT NULL,
+	email		varchar(254)	NOT NULL,
+	team_number	integer			NOT NULL,
+	username	varchar(32)		NOT NULL,
+	role		varchar(32)		NOT NULL,
+	UNIQUE (email),
+	CONSTRAINT users_pkey PRIMARY KEY (user_id),
+	CONSTRAINT chk_users_min_team_number CHECK (team_number >= 0)
+);
+
+
+CREATE TABLE credentials (
+	user_id		bigint			NOT NULL,
+	password	varchar(256)	NOT NULL,
+	UNIQUE (user_id),
+	CONSTRAINT fk__credentials__user_id FOREIGN KEY (user_id)
+		REFERENCES users (user_id)
+		ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX idx_credentials
+	ON credentials USING btree (user_id)
+;
+
+CREATE TABLE tokens (
+	token_id	uuid	NOT NULL DEFAULT gen_random_uuid(),
+	user_id		bigint	NOT NULL,
+	time_created timestamp(0) with time zone NOT NULL,
+	CONSTRAINT tokens_pkey PRIMARY KEY (token_id),
+	CONSTRAINT fk__tokens__user_id FOREIGN KEY (user_id)
+		REFERENCES users (user_id)
+		ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V16__Event_data_sharing.sql
+++ b/src/main/resources/db/migration/V16__Event_data_sharing.sql
@@ -1,0 +1,3 @@
+ALTER TABLE events
+	ADD COLUMN shared
+	BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
- Add a new column `shared` to the events table.
- When two teams using the same `event_code` and `secret_code` both have their `shared` flags set to true, the `/team/{teamNumber}/gameYear/{gameYear}/event/{eventCode}` endpoint will return the combined match data of both teams.

Note some important behaviors:

- Match data is shared, not notes or inspections (will want to share inspections too, but never notes)
- Teams with `shared=false` cannot see data from teams with `shared=true`. In other words, you can't benefit from scouting collaboration unless you're also collaborating.